### PR TITLE
Add _arb_set to improve reusability

### DIFF
--- a/src/arb/ArbTypes.jl
+++ b/src/arb/ArbTypes.jl
@@ -73,63 +73,18 @@ type arb <: FieldElem
     return z
   end
 
-  function arb(x::arb, p::Int)
+  function arb(x::Union{Int, UInt, Float64, fmpz, fmpq, BigFloat, AbstractString, arb}, p::Int)
     z = new()
     ccall((:arb_init, :libarb), Void, (Ptr{arb}, ), &z)
-    ccall((:arb_set_round, :libarb), Void,
-                (Ptr{arb}, Ptr{arb}, Int), &z, &x, p)
+    _arb_set(z, x, p)
     finalizer(z, _arb_clear_fn)
     return z
   end
 
-  function arb(s::AbstractString, p::Int)
-    s = bytestring(s)
+  function arb(x::Union{Int, UInt, Float64, fmpz, BigFloat, arb})
     z = new()
     ccall((:arb_init, :libarb), Void, (Ptr{arb}, ), &z)
-    err = ccall((:arb_set_str, :libarb), Int32, (Ptr{arb}, Ptr{UInt8}, Int), &z, s, p)
-    finalizer(z, _arb_clear_fn)
-    err == 0 || error("Invalid real string: $(repr(s))")
-    return z
-  end
-
-  function arb(x::Int)
-    z = new()
-    ccall((:arb_init, :libarb), Void, (Ptr{arb}, ), &z)
-    ccall((:arb_set_si, :libarb), Void, (Ptr{arb}, Int), &z, x)
-    finalizer(z, _arb_clear_fn)
-    return z
-  end
- 
-  function arb(i::UInt)
-    z = new()
-    ccall((:arb_init, :libarb), Void, (Ptr{arb}, ), &z)
-    ccall((:arb_set_ui, :libarb), Void, (Ptr{arb}, UInt), &z, i)
-    finalizer(z, _arb_clear_fn)
-    return z
-  end
-
-  function arb(x::fmpz)
-    z = new()
-    ccall((:arb_init, :libarb), Void, (Ptr{arb}, ), &z)
-    ccall((:arb_set_fmpz, :libarb), Void, (Ptr{arb}, Ptr{fmpz}), &z, &x)
-    finalizer(z, _arb_clear_fn)
-    return z
-  end
- 
-  function arb(x::fmpz, p::Int)
-    z = new()
-    ccall((:arb_init, :libarb), Void, (Ptr{arb}, ), &z)
-    ccall((:arb_set_round_fmpz, :libarb), Void,
-                (Ptr{arb}, Ptr{fmpz}, Int), &z, &x, p)
-    finalizer(z, _arb_clear_fn)
-    return z
-  end
- 
-  function arb(x::fmpq, p::Int)
-    z = new()
-    ccall((:arb_init, :libarb), Void, (Ptr{arb}, ), &z)
-    ccall((:arb_set_fmpq, :libarb), Void,
-                (Ptr{arb}, Ptr{fmpq}, Int), &z, &x, p)
+    _arb_set(z, x)
     finalizer(z, _arb_clear_fn)
     return z
   end
@@ -139,23 +94,6 @@ type arb <: FieldElem
     ccall((:arb_init, :libarb), Void, (Ptr{arb}, ), &z)
     ccall((:arb_set, :libarb), Void, (Ptr{arb}, Ptr{arb}), &z, &mid)
     ccall((:arb_add_error, :libarb), Void, (Ptr{arb}, Ptr{arb}), &z, &rad)
-    finalizer(z, _arb_clear_fn)
-    return z
-  end
-
-  function arb(x::Float64)
-    z = new()
-    ccall((:arb_init, :libarb), Void, (Ptr{arb}, ), &z)
-    ccall((:arb_set_d, :libarb), Void, (Ptr{arb}, Float64), &z, x)
-    finalizer(z, _arb_clear_fn)
-    return z
-  end
-
-  function arb(x::Float64, p::Int)
-    z = new()
-    ccall((:arb_init, :libarb), Void, (Ptr{arb}, ), &z)
-    ccall((:arb_set_d, :libarb), Void, (Ptr{arb}, Float64), &z, x)
-    ccall((:arb_set_round, :libarb), Void, (Ptr{arb}, Ptr{arb}, Int), &z, &z, p)
     finalizer(z, _arb_clear_fn)
     return z
   end
@@ -205,6 +143,21 @@ type AcbField <: Field
 end
 
 prec(x::AcbField) = x.prec
+
+type acb_struct
+  real_mid_exp::Int     # fmpz
+  real_mid_size::UInt64 # mp_size_t
+  real_mid_d1::Int64    # mantissa_struct
+  real_mid_d2::Int64
+  real_rad_exp::Int     # fmpz
+  real_rad_man::UInt64
+  imag_mid_exp::Int     # fmpz
+  imag_mid_size::UInt64 # mp_size_t
+  imag_mid_d1::Int64    # mantissa_struct
+  imag_mid_d2::Int64
+  imag_rad_exp::Int     # fmpz
+  imag_rad_man::UInt64
+end
 
 type acb <: FieldElem
   real_mid_exp::Int     # fmpz

--- a/src/arb/ArbTypes.jl
+++ b/src/arb/ArbTypes.jl
@@ -144,21 +144,6 @@ end
 
 prec(x::AcbField) = x.prec
 
-type acb_struct
-  real_mid_exp::Int     # fmpz
-  real_mid_size::UInt64 # mp_size_t
-  real_mid_d1::Int64    # mantissa_struct
-  real_mid_d2::Int64
-  real_rad_exp::Int     # fmpz
-  real_rad_man::UInt64
-  imag_mid_exp::Int     # fmpz
-  imag_mid_size::UInt64 # mp_size_t
-  imag_mid_d1::Int64    # mantissa_struct
-  imag_mid_d2::Int64
-  imag_rad_exp::Int     # fmpz
-  imag_rad_man::UInt64
-end
-
 type acb <: FieldElem
   real_mid_exp::Int     # fmpz
   real_mid_size::UInt # mp_size_t

--- a/src/arb/arb.jl
+++ b/src/arb/arb.jl
@@ -925,6 +925,80 @@ end
 
 ################################################################################
 #
+#  Unsafe setting
+#
+################################################################################
+
+for (typeofx, passtoc) in ((arb, Ref{arb}), (Ptr{arb}, Ptr{arb}))
+  for (f,t) in (("arb_set_si", Int), ("arb_set_ui", UInt),
+                ("arb_set_d", Float64))
+    @eval begin
+      function _arb_set(x::($typeofx), y::($t))
+        ccall(($f, :libarb), Void, (($passtoc), ($t)), x, y)
+      end
+
+      function _arb_set(x::($typeofx), y::($t), p::Int)
+        _arb_set(x, y)
+        ccall((:arb_set_round, :libarb), Void,
+                    (($passtoc), ($passtoc), Int), x, x, p)
+      end
+
+      function _arb_set(x::($typeofx), y::fmpz)
+        ccall((:arb_set_fmpz, :libarb), Void, (($passtoc), Ptr{fmpz}), x, &y)
+      end
+
+      function _arb_set(x::($typeofx), y::fmpz, p::Int)
+        ccall((:arb_set_round_fmpz, :libarb), Void,
+                    (($passtoc), Ptr{fmpz}, Int), x, &y, p)
+      end
+
+      function _arb_set(x::($typeofx), y::fmpq, p::Int)
+        ccall((:arb_set_fmpq, :libarb), Void,
+                    (($passtoc), Ptr{fmpq}, Int), x, &y, p)
+      end
+
+      function _arb_set(x::($typeofx), y::arb)
+        ccall((:arb_set, :libarb), Void, (($passtoc), Ptr{arb}, Int), x, &y)
+      end
+
+      function _arb_set(x::($typeofx), y::arb, p::Int)
+        ccall((:arb_set_round, :libarb), Void,
+                    (($passtoc), Ptr{arb}, Int), x, &y, p)
+      end
+
+      function _arb_set(x::($typeofx), y::AbstractString, p::Int)
+        s = bytestring(y)
+        err = ccall((:arb_set_str, :libarb), Int32,
+                    (($passtoc), Ptr{UInt8}, Int), x, s, p)
+        err == 0 || error("Invalid real string: $(repr(s))")
+      end
+
+      function _arb_set(x::($typeofx), y::BigFloat)
+        m = ccall((:arb_mid_ptr, :libarb), Ptr{arf_struct},
+                    (($passtoc), ), x)
+        r = ccall((:arb_rad_ptr, :libarb), Ptr{mag_struct},
+                    (($passtoc), ), x)
+        ccall((:arf_set_mpfr, :libarb), Void,
+                    (Ptr{arf_struct}, Ptr{BigFloat}), m, &y)
+        ccall((:mag_zero, :libarb), Void, (Ptr{mag_struct}, ), r)
+      end
+
+      function _arb_set(x::($typeofx), y::BigFloat, p::Int)
+        m = ccall((:arb_mid_ptr, :libarb), Ptr{arf_struct}, (($passtoc), ), x)
+        r = ccall((:arb_rad_ptr, :libarb), Ptr{mag_struct}, (($passtoc), ), x)
+        ccall((:arf_set_mpfr, :libarb), Void,
+                    (Ptr{arf_struct}, Ptr{BigFloat}), m, &y)
+        ccall((:mag_zero, :libarb), Void, (Ptr{mag_struct}, ), r)
+        ccall((:arb_set_round, :libarb), Void,
+                    (($passtoc), ($passtoc), Int), x, x, p)
+      end
+    end
+  end
+end
+  
+
+################################################################################
+#
 #  Parent object overloading
 #
 ################################################################################


### PR DESCRIPTION
@fredrik-johansson 
I used some macro magic to provide non-exposed helper function(s)
```julia
_arb_set(x::arb, y::T)
_arb_set(x::Ptr{arb}, y::T)
_arb_set(x::arb, y::T, p::Int)
_arb_set(x::Ptr{arb}, y::T, p::Int)
```
where `T <: Union{Int, UInt, fmpz, fmpq, Float64, BigFloat64, AbstractString, arb}` (or a subset thereof), in arb.jl.
They will spare me from writing the same things over and over again. Using them I rewrote the arb constructors. I have added the pointer variant, so that when wrapping arb_mat I can do
```julia
setindex!(x::arb_mat, y::T, i::Int, j::Int)
  el = ccall((:arb_mat_entry, :libarb), ...) # el is of type Ptr{arb}
  _arb_set(el, y, prec(base_ring(x)))
end
```
and
```julia
function arb_mat(arr::Array{2, T}, p::Int)
  z = ccall((...))
  # for all entries do
    el = ccall((:arb_mat_entry, :libarb), ...)
    _arb_set(el, arr[i, j])
end
```
They could also help with the `setcoeff!(x::arb_poly, y::T, n::Int)` or constructors `arb_poly(Array{1, T})`.

If we agree that they are useful, I will add corresponding functions for acb.

P.S. I have also added a constructor `arb(::BigFloat)`.