### PR TITLE
fix return order of rref(x::fmpz_mat)

### DIFF
--- a/src/flint/fmpz_mat.jl
+++ b/src/flint/fmpz_mat.jl
@@ -871,7 +871,7 @@ function rref(x::fmpz_mat)
    d = fmpz()
    ccall((:fmpz_mat_rref, :libflint), Void,
          (Ptr{fmpz_mat}, Ptr{fmpz}, Ptr{fmpz_mat}), &z, &d, &x)
-   return z, d
+   return d, z
 end
 
 ###############################################################################


### PR DESCRIPTION
Return order was inconsistent with documentation.
