### PR TITLE
fix most deprecation warnings in Julia v0.5

### DIFF
--- a/src/Nemo.jl
+++ b/src/Nemo.jl
@@ -1,14 +1,14 @@
-VERSION >= v"0.4.0-dev+6521" && __precompile__()
+__precompile__()
 
 module Nemo
- 
-import Base: Array, abs, asin, asinh, atan, atanh, base, bin, call,
+
+import Base: Array, abs, asin, asinh, atan, atanh, base, bin,
              checkbounds, convert, cmp, contains, cos, cosh, dec,
              deepcopy, deepcopy_internal, den, deserialize, det, div, divrem,
              exp, factor, gcd, gcdx, getindex, hash, hcat, hex, intersect, inv,
              invmod, isequal, isfinite, isless, isprime, isqrt, isreal, lcm,
              ldexp, length, log, lufact, lufact!, mod, ndigits, nextpow2, norm,
-             nullspace, num, oct, one, parent, parity, parseint, precision,
+             nullspace, num, oct, one, parent, parity, precision,
              prevpow2, promote_rule, rank, Rational, rem, reverse, serialize,
              setindex!, show, sign, sin, sinh, size, sqrt, string, sub, tan,
              tanh, trace, trailing_zeros, transpose, transpose!, truncate,
@@ -49,12 +49,11 @@ include("AbstractTypes.jl")
 #   Set up environment / load libraries
 #
 ###############################################################################
-
-on_windows64 = (@windows ? true : false) && (Int == Int64)
+const on_windows64 = is_windows() && (Int == Int64)
 
 const pkgdir = realpath(joinpath(dirname(@__FILE__), ".."))
 const libdir = joinpath(pkgdir, "local", "lib")
-if (@windows ? true : false)
+@static if is_windows()
    const libgmp = joinpath(pkgdir, "local", "lib", "libgmp-16")
 else
    const libgmp = joinpath(pkgdir, "local", "lib", "libgmp")
@@ -79,8 +78,8 @@ end
 
 function __init__()
 
-   on_windows = @windows ? true : false
-   on_linux = @linux ? true : false
+   const on_windows = is_windows()
+   const on_linux = is_linux()
 
    if "HOSTNAME" in keys(ENV) && ENV["HOSTNAME"] == "juliabox"
        push!(Libdl.DL_LOAD_PATH, "/usr/local/lib")
@@ -191,10 +190,10 @@ end
 function create_accessors(T, S, handle)
    accessor_name = gensym()
    @eval begin
-      function $(symbol(:get, accessor_name))(a::$T)
+      function $(Symbol(:get, accessor_name))(a::$T)
          return a.auxilliary_data[$handle]::$S
       end,
-      function $(symbol(:set, accessor_name))(a::$T, b::$S)
+      function $(Symbol(:set, accessor_name))(a::$T, b::$S)
          if $handle > length(a.auxilliary_data)
             resize(a.auxilliary_data, $handle)
          end

--- a/src/antic/nf_elem.jl
+++ b/src/antic/nf_elem.jl
@@ -832,42 +832,42 @@ Base.promote_rule(::Type{nf_elem}, ::Type{fmpq_poly}) = nf_elem
 #
 ###############################################################################
 
-function Base.call(a::AnticNumberField)
+function (a::AnticNumberField)()
    z = nf_elem(a)
    ccall((:nf_elem_set_si, :libflint), Void,
          (Ptr{nf_elem}, Int, Ptr{AnticNumberField}), &z, 0, &a)
    return z
 end
 
-function Base.call(a::AnticNumberField, c::Int)
+function (a::AnticNumberField)(c::Int)
    z = nf_elem(a)
    ccall((:nf_elem_set_si, :libflint), Void,
          (Ptr{nf_elem}, Int, Ptr{AnticNumberField}), &z, c, &a)
    return z
 end
 
-Base.call(a::AnticNumberField, c::Integer) = a(fmpz(c))
+(a::AnticNumberField)(c::Integer) = a(fmpz(c))
 
-function Base.call(a::AnticNumberField, c::fmpz)
+function (a::AnticNumberField)(c::fmpz)
    z = nf_elem(a)
    ccall((:nf_elem_set_fmpz, :libflint), Void,
          (Ptr{nf_elem}, Ptr{fmpz}, Ptr{AnticNumberField}), &z, &c, &a)
    return z
 end
 
-function Base.call(a::AnticNumberField, c::fmpq)
+function (a::AnticNumberField)(c::fmpq)
    z = nf_elem(a)
    ccall((:nf_elem_set_fmpq, :libflint), Void,
          (Ptr{nf_elem}, Ptr{fmpq}, Ptr{AnticNumberField}), &z, &c, &a)
    return z
 end
 
-function Base.call(a::AnticNumberField, b::nf_elem)
+function (a::AnticNumberField)(b::nf_elem)
    parent(b) != a && error("Cannot coerce number field element")
    return b
 end
 
-function Base.call(a::AnticNumberField, pol::fmpq_poly)
+function (a::AnticNumberField)(pol::fmpq_poly)
    pol = parent(a.pol)(pol) # check pol has correct parent
    z = nf_elem(a)
    if length(pol) >= length(a.pol)
@@ -878,7 +878,7 @@ function Base.call(a::AnticNumberField, pol::fmpq_poly)
    return z
 end
 
-function Base.call(a::FmpqPolyRing, b::nf_elem)
+function (a::FmpqPolyRing)(b::nf_elem)
    parent(parent(b).pol) != a && error("Cannot coerce from number field to polynomial ring")
    r = a()
    ccall((:nf_elem_get_fmpq_poly, :libflint), Void,

--- a/src/arb/acb.jl
+++ b/src/arb/acb.jl
@@ -1496,21 +1496,21 @@ end
 #
 ################################################################################
 
-function call(r::AcbField)
+function (r::AcbField)()
   z = acb()
   z.parent = r
   return z
 end
 
-function call(r::AcbField, x::Union{Int, UInt, fmpz, fmpq, arb, acb, Float64, BigFloat, AbstractString})
+function (r::AcbField)(x::Union{Int, UInt, fmpz, fmpq, arb, acb, Float64, BigFloat, AbstractString})
   z = acb(x, r.prec)
   z.parent = r
   return z
 end
 
-call(r::AcbField, x::Integer) = r(fmpz(x))
+(r::AcbField)(x::Integer) = r(fmpz(x))
 
-function call{T <: Union{Int, UInt, fmpz, fmpq, arb, Float64, BigFloat, AbstractString}}(r::AcbField, x::T, y::T)
+function (r::AcbField){T <: Union{Int, UInt, fmpz, fmpq, arb, Float64, BigFloat, AbstractString}}(x::T, y::T)
   z = acb(x, y, r.prec)
   z.parent = r
   return z

--- a/src/arb/acb_mat.jl
+++ b/src/arb/acb_mat.jl
@@ -601,13 +601,13 @@ end
 #
 ###############################################################################
 
-function call(x::AcbMatSpace)
+function (x::AcbMatSpace)()
   z = acb_mat(x.rows, x.cols)
   z.parent = x
   return z
 end
 
-function call(x::AcbMatSpace, y::fmpz_mat)
+function (x::AcbMatSpace)(y::fmpz_mat)
   (x.cols != cols(y) || x.rows != rows(y)) &&
       error("Dimensions are wrong")
   z = acb_mat(y, prec(x))
@@ -615,7 +615,7 @@ function call(x::AcbMatSpace, y::fmpz_mat)
   return z
 end
 
-function call(x::AcbMatSpace, y::arb_mat)
+function (x::AcbMatSpace)(y::arb_mat)
   (x.cols != cols(y) || x.rows != rows(y)) &&
       error("Dimensions are wrong")
   z = acb_mat(y, prec(x))
@@ -624,36 +624,35 @@ function call(x::AcbMatSpace, y::arb_mat)
 end
 
 
-function call{T <: Union{Int, UInt, Float64, fmpz, fmpq, BigFloat, arb, acb,
-                         AbstractString}}(x::AcbMatSpace, y::Array{T, 2})
+function (x::AcbMatSpace){T <: Union{Int, UInt, Float64, fmpz, fmpq, BigFloat,
+                          arb, acb, AbstractString}}(y::Array{T, 2})
   (x.rows, x.cols) != size(y) && error("Dimensions are wrong")
   z = acb_mat(x.rows, x.cols, y, prec(x))
   z.parent = x
   return z
 end
 
-call{T <: Union{Int, UInt, Float64, fmpz, fmpq, BigFloat, arb, acb,
-                AbstractString}}(x::AcbMatSpace, y::Array{T, 1}) = x(y'')
+(x::AcbMatSpace){T <: Union{Int, UInt, Float64, fmpz, fmpq, BigFloat, arb, acb,
+                 AbstractString}}(y::Array{T, 1}) = x(y'')
 
 
-function call{T <: Union{Int, UInt, Float64, fmpz, fmpq, BigFloat, arb,
-                         AbstractString}}(x::AcbMatSpace,
-                                          y::Array{Tuple{T, T}, 2})
+function (x::AcbMatSpace){T <: Union{Int, UInt, Float64, fmpz, fmpq, BigFloat,
+                                     arb, AbstractString}}(y::Array{Tuple{T, T}, 2})
   (x.rows, x.cols) != size(y) && error("Dimensions are wrong")
   z = acb_mat(x.rows, x.cols, y, prec(x))
   z.parent = x
   return z
 end
 
-call{T <: Union{Int, UInt, Float64, fmpz, fmpq, BigFloat, AbstractString,
-                arb}}(x::AcbMatSpace, y::Array{Tuple{T, T}, 1}) = x(y'')
+(x::AcbMatSpace){T <: Union{Int, UInt, Float64, fmpz, fmpq, BigFloat,
+                 AbstractString, arb}}(y::Array{Tuple{T, T}, 1}) = x(y'')
 
 
-call{T <: Union{Int, UInt, fmpz, fmpq, Float64, BigFloat, arb, acb,
-                AbstractString}}(x::ArbMatSpace, y::Array{T, 1}) = x(y'')
+(x::ArbMatSpace){T <: Union{Int, UInt, fmpz, fmpq, Float64, BigFloat, arb, acb,
+                            AbstractString}}(y::Array{T, 1}) = x(y'')
 
-function call(x::AcbMatSpace, y::Union{Int, UInt, fmpz, fmpq, Float64,
-                          BigFloat, arb, acb, AbstractString})
+function (x::AcbMatSpace)(y::Union{Int, UInt, fmpz, fmpq, Float64,
+                                   BigFloat, arb, acb, AbstractString})
   z = x()
   for i in 1:rows(z)
       for j = 1:cols(z)
@@ -667,7 +666,7 @@ function call(x::AcbMatSpace, y::Union{Int, UInt, fmpz, fmpq, Float64,
    return z
 end
 
-call(x::AcbMatSpace, y::acb_mat) = y
+(x::AcbMatSpace)(y::acb_mat) = y
 
 ###############################################################################
 #

--- a/src/arb/acb_poly.jl
+++ b/src/arb/acb_poly.jl
@@ -867,43 +867,43 @@ Base.promote_rule(::Type{acb_poly}, ::Type{arb_poly}) = acb_poly
 #
 ################################################################################
 
-function Base.call(a::AcbPolyRing)
+function (a::AcbPolyRing)()
    z = acb_poly()
    z.parent = a
    return z
 end
 
-function Base.call(a::AcbPolyRing, b::Union{Int,fmpz,fmpq,Float64,Complex{Float64},Complex{Int},arb,acb})
+function (a::AcbPolyRing)(b::Union{Int,fmpz,fmpq,Float64,Complex{Float64},Complex{Int},arb,acb})
    z = acb_poly(base_ring(a)(b), a.base_ring.prec)
    z.parent = a
    return z
 end
 
-function Base.call(a::AcbPolyRing, b::Array{acb, 1})
+function (a::AcbPolyRing)(b::Array{acb, 1})
    z = acb_poly(b, a.base_ring.prec)
    z.parent = a
    return z
 end
 
-function Base.call(a::AcbPolyRing, b::fmpz_poly)
+function (a::AcbPolyRing)(b::fmpz_poly)
    z = acb_poly(b, a.base_ring.prec)
    z.parent = a
    return z
 end
 
-function Base.call(a::AcbPolyRing, b::fmpq_poly)
+function (a::AcbPolyRing)(b::fmpq_poly)
    z = acb_poly(b, a.base_ring.prec)
    z.parent = a
    return z
 end
 
-function Base.call(a::AcbPolyRing, b::arb_poly)
+function (a::AcbPolyRing)(b::arb_poly)
    z = acb_poly(b, a.base_ring.prec)
    z.parent = a
    return z
 end
 
-function Base.call(a::AcbPolyRing, b::acb_poly)
+function (a::AcbPolyRing)(b::acb_poly)
    z = acb_poly(b, a.base_ring.prec)
    z.parent = a
    return z

--- a/src/arb/arb.jl
+++ b/src/arb/arb.jl
@@ -1691,63 +1691,63 @@ end
 #
 ################################################################################
 
-function call(r::ArbField)
+function (r::ArbField)()
   z = arb()
   z.parent = r
   return z
 end
 
-function call(r::ArbField, x::Int)
+function (r::ArbField)(x::Int)
   z = arb(fmpz(x), r.prec)
   z.parent = r
   return z
 end
 
-function call(r::ArbField, x::UInt)
+function (r::ArbField)(x::UInt)
   z = arb(fmpz(x), r.prec)
   z.parent = r
   return z
 end
 
-function call(r::ArbField, x::fmpz)
+function (r::ArbField)(x::fmpz)
   z = arb(x, r.prec)
   z.parent = r
   return z
 end
 
-call(r::ArbField, x::Integer) = r(fmpz(x))
+(r::ArbField)(x::Integer) = r(fmpz(x))
 
-function call(r::ArbField, x::fmpq)
+function (r::ArbField)(x::fmpq)
   z = arb(x, r.prec)
   z.parent = r
   return z
 end
-  
-#function call(r::ArbField, x::arf)
+
+#function (r::ArbField)(x::arf)
 #  z = arb(arb(x), r.prec)
 #  z.parent = r
 #  return z
 #end
 
-function call(r::ArbField, x::Float64)
+function (r::ArbField)(x::Float64)
   z = arb(x, r.prec)
   z.parent = r
   return z
 end
 
-function call(r::ArbField, x::arb)
+function (r::ArbField)(x::arb)
   z = arb(x, r.prec)
   z.parent = r
   return z
 end
 
-function call(r::ArbField, x::AbstractString)
+function (r::ArbField)(x::AbstractString)
   z = arb(x, r.prec)
   z.parent = r
   return z
 end
 
-function call(r::ArbField, x::Irrational)
+function (r::ArbField)(x::Irrational)
   if x == pi
     return const_pi(r)
   elseif x == e
@@ -1757,7 +1757,7 @@ function call(r::ArbField, x::Irrational)
   end
 end
 
-function call(r::ArbField, x::BigFloat)
+function (r::ArbField)(x::BigFloat)
   z = arb(x, r.prec)
   z.parent = r
   return z

--- a/src/arb/arb_mat.jl
+++ b/src/arb/arb_mat.jl
@@ -564,13 +564,13 @@ end
 #
 ###############################################################################
 
-function call(x::ArbMatSpace)
+function (x::ArbMatSpace)()
   z = arb_mat(x.rows, x.cols)
   z.parent = x
   return z
 end
 
-function call(x::ArbMatSpace, y::fmpz_mat)
+function (x::ArbMatSpace)(y::fmpz_mat)
   (x.cols != cols(y) || x.rows != rows(y)) &&
       error("Dimensions are wrong")
   z = arb_mat(y, prec(x))
@@ -578,18 +578,18 @@ function call(x::ArbMatSpace, y::fmpz_mat)
   return z
 end
 
-function call{T <: Union{Int, UInt, fmpz, fmpq, Float64, BigFloat, arb,
-                         AbstractString}}(x::ArbMatSpace, y::Array{T, 2})
+function (x::ArbMatSpace){T <: Union{Int, UInt, fmpz, fmpq, Float64, BigFloat,
+                                     arb, AbstractString}}(y::Array{T, 2})
   (x.rows, x.cols) != size(y) && error("Dimensions are wrong")
   z = arb_mat(x.rows, x.cols, y, prec(x))
   z.parent = x
   return z
 end
 
-call{T <: Union{Int, UInt, fmpz, fmpq, Float64, BigFloat, arb,
-                AbstractString}}(x::ArbMatSpace, y::Array{T, 1}) = x(y'')
+(x::ArbMatSpace){T <: Union{Int, UInt, fmpz, fmpq, Float64, BigFloat, arb,
+                            AbstractString}}(y::Array{T, 1}) = x(y'')
 
-function call(x::ArbMatSpace, y::Union{Int, UInt, fmpz, fmpq, Float64,
+function (x::ArbMatSpace)(y::Union{Int, UInt, fmpz, fmpq, Float64,
                           BigFloat, arb, AbstractString})
   z = x()
   for i in 1:rows(z)
@@ -604,7 +604,7 @@ function call(x::ArbMatSpace, y::Union{Int, UInt, fmpz, fmpq, Float64,
    return z
 end
 
-call(x::ArbMatSpace, y::arb_mat) = y
+(x::ArbMatSpace)(y::arb_mat) = y
 
 ###############################################################################
 #

--- a/src/arb/arb_poly.jl
+++ b/src/arb/arb_poly.jl
@@ -743,37 +743,37 @@ Base.promote_rule(::Type{arb_poly}, ::Type{fmpq_poly}) = arb_poly
 #
 ################################################################################
 
-function Base.call(a::ArbPolyRing)
+function (a::ArbPolyRing)()
    z = arb_poly()
    z.parent = a
    return z
 end
 
-function Base.call(a::ArbPolyRing, b::Union{Int,fmpz,fmpq,Float64,arb})
+function (a::ArbPolyRing)(b::Union{Int,fmpz,fmpq,Float64,arb})
    z = arb_poly(base_ring(a)(b), a.base_ring.prec)
    z.parent = a
    return z
 end
 
-function Base.call(a::ArbPolyRing, b::Array{arb, 1})
+function (a::ArbPolyRing)(b::Array{arb, 1})
    z = arb_poly(b, a.base_ring.prec)
    z.parent = a
    return z
 end
 
-function Base.call(a::ArbPolyRing, b::fmpz_poly)
+function (a::ArbPolyRing)(b::fmpz_poly)
    z = arb_poly(b, a.base_ring.prec)
    z.parent = a
    return z
 end
 
-function Base.call(a::ArbPolyRing, b::fmpq_poly)
+function (a::ArbPolyRing)(b::fmpq_poly)
    z = arb_poly(b, a.base_ring.prec)
    z.parent = a
    return z
 end
 
-function Base.call(a::ArbPolyRing, b::arb_poly)
+function (a::ArbPolyRing)(b::arb_poly)
    z = arb_poly(b, a.base_ring.prec)
    z.parent = a
    return z

--- a/src/flint/fmpq.jl
+++ b/src/flint/fmpq.jl
@@ -683,25 +683,25 @@ end
 #
 ###############################################################################
 
-call(a::FlintRationalField) = fmpq(fmpz(0), fmpz(1))
+(a::FlintRationalField)() = fmpq(fmpz(0), fmpz(1))
 
-call(a::FlintRationalField, b::Rational{BigInt}) = fmpq(b) 
+(a::FlintRationalField)(b::Rational{BigInt}) = fmpq(b)
 
-call(a::FlintRationalField, b::Integer) = fmpq(b)
+(a::FlintRationalField)(b::Integer) = fmpq(b)
 
-call(a::FlintRationalField, b::Int, c::Int) = fmpq(b, c)
+(a::FlintRationalField)(b::Int, c::Int) = fmpq(b, c)
 
-call(a::FlintRationalField, b::fmpz) = fmpq(b)
+(a::FlintRationalField)(b::fmpz) = fmpq(b)
 
-call(a::FlintRationalField, b::Integer, c::Integer) = fmpq(b, c)
+(a::FlintRationalField)(b::Integer, c::Integer) = fmpq(b, c)
 
-call(a::FlintRationalField, b::fmpz, c::Integer) = fmpq(b, c)
+(a::FlintRationalField)(b::fmpz, c::Integer) = fmpq(b, c)
 
-call(a::FlintRationalField, b::Integer, c::fmpz) = fmpq(b, c)
+(a::FlintRationalField)(b::Integer, c::fmpz) = fmpq(b, c)
 
-call(a::FlintRationalField, b::fmpz, c::fmpz) = fmpq(b, c)
+(a::FlintRationalField)(b::fmpz, c::fmpz) = fmpq(b, c)
 
-call(a::FlintRationalField, b::fmpq) = b
+(a::FlintRationalField)(b::fmpq) = b
 
 ###############################################################################
 #

--- a/src/flint/fmpq_mat.jl
+++ b/src/flint/fmpq_mat.jl
@@ -603,58 +603,58 @@ end
 #
 ###############################################################################
 
-function Base.call(a::FmpqMatSpace)
+function (a::FmpqMatSpace)()
    z = fmpq_mat(a.rows, a.cols)
    z.parent = a
    return z
 end
 
-function Base.call(a::FmpqMatSpace, arr::Array{fmpq, 2})
+function (a::FmpqMatSpace)(arr::Array{fmpq, 2})
    z = fmpq_mat(a.rows, a.cols, arr)
    z.parent = a
    return z
 end
 
-function Base.call{T <: Integer}(a::FmpqMatSpace, arr::Array{T, 2})
+function (a::FmpqMatSpace){T <: Integer}(arr::Array{T, 2})
    z = fmpq_mat(a.rows, a.cols, arr)
    z.parent = a
    return z
 end
 
-function Base.call(a::FmpqMatSpace, arr::Array{fmpq, 1})
+function (a::FmpqMatSpace)(arr::Array{fmpq, 1})
    z = fmpq_mat(a.rows, a.cols, arr)
    z.parent = a
    return z
 end
 
-Base.call{T <: Integer}(a::FmpqMatSpace, arr::Array{T, 1}) = a(arr'')
+(a::FmpqMatSpace){T <: Integer}(arr::Array{T, 1}) = a(arr'')
 
-function Base.call(a::FmpqMatSpace, d::fmpq)
+function (a::FmpqMatSpace)(d::fmpq)
    z = fmpq_mat(a.rows, a.cols, d)
    z.parent = a
    return z
 end
 
-function Base.call(a::FmpqMatSpace, d::fmpz)
+function (a::FmpqMatSpace)(d::fmpz)
    z = fmpq_mat(a.rows, a.cols, fmpq(d))
    z.parent = a
    return z
 end
 
-function Base.call(a::FmpqMatSpace, d::Integer)
+function (a::FmpqMatSpace)(d::Integer)
    z = fmpq_mat(a.rows, a.cols, fmpq(d))
    z.parent = a
    return z
 end
 
-function Base.call(a::FmpqMatSpace, M::fmpz_mat)
+function (a::FmpqMatSpace)(M::fmpz_mat)
    (a.cols == cols(M) && a.rows == rows(M)) || error("wrong matrix dimension")
    z = a()
    ccall((:fmpq_mat_set_fmpz_mat, :libflint), Void, (Ptr{fmpq_mat}, Ptr{fmpz_mat}), &z, &M)
    return z
 end
 
-Base.call(a::FmpqMatSpace, d::fmpq_mat) = d
+(a::FmpqMatSpace)(d::fmpq_mat) = d
 
 ###############################################################################
 #

--- a/src/flint/fmpq_poly.jl
+++ b/src/flint/fmpq_poly.jl
@@ -661,7 +661,7 @@ Base.promote_rule(::Type{fmpq_poly}, ::Type{fmpq}) = fmpq_poly
 #
 ###############################################################################
 
-Base.call(f::fmpq_poly, a::fmpq) = evaluate(f, a)
+(f::fmpq_poly)(a::fmpq) = evaluate(f, a)
 
 ###############################################################################
 #
@@ -669,45 +669,45 @@ Base.call(f::fmpq_poly, a::fmpq) = evaluate(f, a)
 #
 ###############################################################################
 
-function Base.call(a::FmpqPolyRing)
+function (a::FmpqPolyRing)()
    z = fmpq_poly()
    z.parent = a
    return z
 end
 
-function Base.call(a::FmpqPolyRing, b::Int)
+function (a::FmpqPolyRing)(b::Int)
    z = fmpq_poly(b)
    z.parent = a
    return z
 end
 
-function Base.call(a::FmpqPolyRing, b::Integer)
+function (a::FmpqPolyRing)(b::Integer)
    z = fmpq_poly(fmpz(b))
    z.parent = a
    return z
 end
 
-function Base.call(a::FmpqPolyRing, b::fmpz)
+function (a::FmpqPolyRing)(b::fmpz)
    z = fmpq_poly(b)
    z.parent = a
    return z
 end
 
-function Base.call(a::FmpqPolyRing, b::fmpq)
+function (a::FmpqPolyRing)(b::fmpq)
    z = fmpq_poly(b)
    z.parent = a
    return z
 end
 
-function Base.call(a::FmpqPolyRing, b::Array{fmpq, 1})
+function (a::FmpqPolyRing)(b::Array{fmpq, 1})
    z = fmpq_poly(b)
    z.parent = a
    return z
 end
 
-Base.call(a::FmpqPolyRing, b::fmpq_poly) = b
+(a::FmpqPolyRing)(b::fmpq_poly) = b
 
-function Base.call(a::FmpqPolyRing, b::fmpz_poly)
+function (a::FmpqPolyRing)(b::fmpz_poly)
    z = fmpq_poly(b)
    z.parent = a
    return z

--- a/src/flint/fmpq_rel_series.jl
+++ b/src/flint/fmpq_rel_series.jl
@@ -732,14 +732,14 @@ Base.promote_rule(::Type{fmpq_rel_series}, ::Type{fmpq}) = fmpq_rel_series
 #
 ###############################################################################
 
-function Base.call(a::FmpqRelSeriesRing)
+function (a::FmpqRelSeriesRing)()
    z = fmpq_rel_series()
    z.prec = a.prec_max
    z.parent = a
    return z
 end
 
-function Base.call(a::FmpqRelSeriesRing, b::Integer)
+function (a::FmpqRelSeriesRing)(b::Integer)
    if b == 0
       z = fmpq_rel_series()
       z.prec = a.prec_max
@@ -750,7 +750,7 @@ function Base.call(a::FmpqRelSeriesRing, b::Integer)
    return z
 end
 
-function Base.call(a::FmpqRelSeriesRing, b::fmpz)
+function (a::FmpqRelSeriesRing)(b::fmpz)
    if b == 0
       z = fmpq_rel_series()
       z.prec = a.prec_max
@@ -761,7 +761,7 @@ function Base.call(a::FmpqRelSeriesRing, b::fmpz)
    return z
 end
 
-function Base.call(a::FmpqRelSeriesRing, b::fmpq)
+function (a::FmpqRelSeriesRing)(b::fmpq)
    if b == 0
       z = fmpq_rel_series()
       z.prec = a.prec_max
@@ -772,12 +772,12 @@ function Base.call(a::FmpqRelSeriesRing, b::fmpq)
    return z
 end
 
-function Base.call(a::FmpqRelSeriesRing, b::fmpq_rel_series)
+function (a::FmpqRelSeriesRing)(b::fmpq_rel_series)
    parent(b) != a && error("Unable to coerce power series")
    return b
 end
 
-function Base.call(a::FmpqRelSeriesRing, b::Array{fmpq, 1}, len::Int, prec::Int)
+function (a::FmpqRelSeriesRing)(b::Array{fmpq, 1}, len::Int, prec::Int)
    z = fmpq_rel_series(b, len, prec)
    z.parent = a
    return z

--- a/src/flint/fmpz.jl
+++ b/src/flint/fmpz.jl
@@ -1146,55 +1146,55 @@ doc"""
 > Return the value of the sigma function, i.e. $\sum_{0 < d \;| x} d^y$. If
 > $y < 0$ we throw a `DomainError()`.
 """
-function sigma(x::fmpz, y::Int) 
+function sigma(x::fmpz, y::Int)
    y < 0 && throw(DomainError())
    z = fmpz()
-   ccall((:fmpz_divisor_sigma, :libflint), Void, 
+   ccall((:fmpz_divisor_sigma, :libflint), Void,
          (Ptr{fmpz}, Ptr{fmpz}, Int), &z, &x, y)
    return z
 end
 
 doc"""
-    eulerphi(x::fmpz) 
+    eulerphi(x::fmpz)
 > Return the value of the Euler phi function at $x$, i.e. the number of
 > positive integers less than $x$ that are coprime with $x$.
 """
-function eulerphi(x::fmpz) 
+function eulerphi(x::fmpz)
    x < 0 && throw(DomainError())
    z = fmpz()
-   ccall((:fmpz_euler_phi, :libflint), Void, 
+   ccall((:fmpz_euler_phi, :libflint), Void,
          (Ptr{fmpz}, Ptr{fmpz}), &z, &x)
    return z
 end
 
 doc"""
-    numpart(x::Int) 
+    numpart(x::Int)
 > Return the number of partitions of $x$. This function is not available on
 > Windows 64.
 """
-function numpart(x::Int) 
-   if (@windows? true : false) && Int == Int64
+function numpart(x::Int)
+   if (@static is_windows() ? true : false) && Int == Int64
       error("not yet supported on win64")
    end
    x < 0 && throw(DomainError())
    z = fmpz()
-   ccall((:partitions_fmpz_ui, :libarb), Void, 
+   ccall((:partitions_fmpz_ui, :libarb), Void,
          (Ptr{fmpz}, UInt), &z, x)
    return z
 end
 
 doc"""
-    numpart(x::fmpz) 
+    numpart(x::fmpz)
 > Return the number of partitions of $x$. This function is not available on
 > Windows 64.
 """
-function numpart(x::fmpz) 
-   if (@windows? true : false) && Int == Int64
+function numpart(x::fmpz)
+   if (@static is_windows() ? true : false) && Int == Int64
       error("not yet supported on win64")
    end
    x < 0 && throw(DomainError())
    z = fmpz()
-   ccall((:partitions_fmpz_fmpz, :libarb), Void, 
+   ccall((:partitions_fmpz_fmpz, :libarb), Void,
          (Ptr{fmpz}, Ptr{fmpz}, Int), &z, &x, 0)
    return z
 end
@@ -1360,21 +1360,21 @@ end
 #
 ###############################################################################
 
-call(::FlintIntegerRing) = fmpz()
+(::FlintIntegerRing)() = fmpz()
 
-call(::FlintIntegerRing, a::Integer) = fmpz(a)
+(::FlintIntegerRing)(a::Integer) = fmpz(a)
 
-call(::FlintIntegerRing, a::AbstractString{}) = fmpz(a)
+(::FlintIntegerRing)(a::AbstractString{}) = fmpz(a)
 
-call(::FlintIntegerRing, a::fmpz) = a
+(::FlintIntegerRing)(a::fmpz) = a
 
-call(::FlintIntegerRing, a::Float64) = fmpz(a)
+(::FlintIntegerRing)(a::Float64) = fmpz(a)
 
-call(::FlintIntegerRing, a::Float32) = fmpz(Float64(a))
+(::FlintIntegerRing)(a::Float32) = fmpz(Float64(a))
 
-call(::FlintIntegerRing, a::Float16) = fmpz(Float64(a))
+(::FlintIntegerRing)(a::Float16) = fmpz(Float64(a))
 
-call(::FlintIntegerRing, a::BigFloat) = fmpz(BigInt(a))
+(::FlintIntegerRing)(a::BigFloat) = fmpz(BigInt(a))
 
 ###############################################################################
 #

--- a/src/flint/fmpz_mat.jl
+++ b/src/flint/fmpz_mat.jl
@@ -1046,45 +1046,45 @@ end
 #
 ###############################################################################
 
-function Base.call(a::FmpzMatSpace)
+function (a::FmpzMatSpace)()
    z = fmpz_mat(a.rows, a.cols)
    z.parent = a
    return z
 end
 
-function Base.call(a::FmpzMatSpace, arr::Array{fmpz, 2})
+function (a::FmpzMatSpace)(arr::Array{fmpz, 2})
    z = fmpz_mat(a.rows, a.cols, arr)
    z.parent = a
    return z
 end
 
-function Base.call{T <: Integer}(a::FmpzMatSpace, arr::Array{T, 2})
+function (a::FmpzMatSpace){T <: Integer}(arr::Array{T, 2})
    z = fmpz_mat(a.rows, a.cols, arr)
    z.parent = a
    return z
 end
 
-function Base.call(a::FmpzMatSpace, arr::Array{fmpz, 1})
+function (a::FmpzMatSpace)(arr::Array{fmpz, 1})
    z = fmpz_mat(a.rows, a.cols, arr)
    z.parent = a
    return z
 end
 
-Base.call{T <: Integer}(a::FmpzMatSpace, arr::Array{T, 1}) = a(arr'')
+(a::FmpzMatSpace){T <: Integer}(arr::Array{T, 1}) = a(arr'')
 
-function Base.call(a::FmpzMatSpace, d::fmpz)
+function (a::FmpzMatSpace)(d::fmpz)
    z = fmpz_mat(a.rows, a.cols, d)
    z.parent = a
    return z
 end
 
-function Base.call(a::FmpzMatSpace, d::Integer)
+function (a::FmpzMatSpace)(d::Integer)
    z = fmpz_mat(a.rows, a.cols, fmpz(d))
    z.parent = a
    return z
 end
 
-Base.call(a::FmpzMatSpace, d::fmpz_mat) = d
+(a::FmpzMatSpace)(d::fmpz_mat) = d
 
 ###############################################################################
 #

--- a/src/flint/fmpz_mod_poly.jl
+++ b/src/flint/fmpz_mod_poly.jl
@@ -842,7 +842,7 @@ Base.promote_rule(::Type{fmpz_mod_poly}, ::Type{GenRes{fmpz}}) = fmpz_mod_poly
 #
 ###############################################################################
 
-function Base.call(f::fmpz_mod_poly, a::GenRes{fmpz})
+function (f::fmpz_mod_poly)(a::GenRes{fmpz})
    if parent(a) != base_ring(f)
       return subst(f, a)
    end
@@ -855,38 +855,38 @@ end
 #
 ################################################################################
 
-function Base.call(R::FmpzModPolyRing)
+function (R::FmpzModPolyRing)()
   z = fmpz_mod_poly(R.n)
   z.parent = R
   return z
 end
 
-function Base.call(R::FmpzModPolyRing, x::fmpz)
+function (R::FmpzModPolyRing)(x::fmpz)
   z = fmpz_mod_poly(R.n, x)
   z.parent = R
   return z
 end
 
-function Base.call(R::FmpzModPolyRing, x::Integer)
+function (R::FmpzModPolyRing)(x::Integer)
   z = fmpz_mod_poly(R.n, fmpz(x))
   z.parent = R
   return z
 end
 
-function Base.call(R::FmpzModPolyRing, x::GenRes{fmpz})
+function (R::FmpzModPolyRing)(x::GenRes{fmpz})
   base_ring(R) != parent(x) && error("Wrong parents")
   z = fmpz_mod_poly(R.n, x.data)
   z.parent = R
   return z
 end
 
-function Base.call(R::FmpzModPolyRing, arr::Array{fmpz, 1})
+function (R::FmpzModPolyRing)(arr::Array{fmpz, 1})
   z = fmpz_mod_poly(R.n, arr)
   z.parent = R
   return z
 end
 
-function Base.call(R::FmpzModPolyRing, arr::Array{GenRes{fmpz}, 1})
+function (R::FmpzModPolyRing)(arr::Array{GenRes{fmpz}, 1})
   if length(arr) > 0
      (base_ring(R) != parent(arr[1])) && error("Wrong parents")
   end
@@ -895,13 +895,13 @@ function Base.call(R::FmpzModPolyRing, arr::Array{GenRes{fmpz}, 1})
   return z
 end
 
-function Base.call(R::FmpzModPolyRing, x::fmpz_poly)
+function (R::FmpzModPolyRing)(x::fmpz_poly)
   z = fmpz_mod_poly(R.n, x)
   z.parent = R
   return z
 end
 
-function Base.call(R::FmpzModPolyRing, f::fmpz_mod_poly)
+function (R::FmpzModPolyRing)(f::fmpz_mod_poly)
    parent(f) != R && error("Unable to coerce polynomial")
    return f
 end

--- a/src/flint/fmpz_mod_rel_series.jl
+++ b/src/flint/fmpz_mod_rel_series.jl
@@ -497,14 +497,14 @@ Base.promote_rule(::Type{fmpz_mod_rel_series}, ::Type{GenRes{fmpz}}) = fmpz_mod_
 #
 ###############################################################################
 
-function Base.call(a::FmpzModRelSeriesRing)
+function (a::FmpzModRelSeriesRing)()
    z = fmpz_mod_rel_series(modulus(base_ring(a)))
    z.prec = a.prec_max
    z.parent = a
    return z
 end
 
-function Base.call(a::FmpzModRelSeriesRing, b::Integer)
+function (a::FmpzModRelSeriesRing)(b::Integer)
    if b == 0
       z = fmpz_mod_rel_series(modulus(base_ring(a)))
       z.prec = a.prec_max
@@ -515,7 +515,7 @@ function Base.call(a::FmpzModRelSeriesRing, b::Integer)
    return z
 end
 
-function Base.call(a::FmpzModRelSeriesRing, b::fmpz)
+function (a::FmpzModRelSeriesRing)(b::fmpz)
    if b == 0
       z = fmpz_mod_rel_series(modulus(base_ring(a)))
       z.prec = a.prec_max
@@ -526,7 +526,7 @@ function Base.call(a::FmpzModRelSeriesRing, b::fmpz)
    return z
 end
 
-function Base.call(a::FmpzModRelSeriesRing, b::GenRes{fmpz})
+function (a::FmpzModRelSeriesRing)(b::GenRes{fmpz})
    if b == 0
       z = fmpz_mod_rel_series(modulus(base_ring(a)))
       z.prec = a.prec_max
@@ -537,18 +537,18 @@ function Base.call(a::FmpzModRelSeriesRing, b::GenRes{fmpz})
    return z
 end
 
-function Base.call(a::FmpzModRelSeriesRing, b::fmpz_mod_rel_series)
+function (a::FmpzModRelSeriesRing)(b::fmpz_mod_rel_series)
    parent(b) != a && error("Unable to coerce power series")
    return b
 end
 
-function Base.call(a::FmpzModRelSeriesRing, b::Array{fmpz, 1}, len::Int, prec::Int)
+function (a::FmpzModRelSeriesRing)(b::Array{fmpz, 1}, len::Int, prec::Int)
    z = fmpz_mod_rel_series(modulus(base_ring(a)), b, len, prec)
    z.parent = a
    return z
 end
 
-function Base.call(a::FmpzModRelSeriesRing, b::Array{GenRes{fmpz}, 1}, len::Int, prec::Int)
+function (a::FmpzModRelSeriesRing)(b::Array{GenRes{fmpz}, 1}, len::Int, prec::Int)
    z = fmpz_mod_rel_series(modulus(base_ring(a)), b, len, prec)
    z.parent = a
    return z

--- a/src/flint/fmpz_poly.jl
+++ b/src/flint/fmpz_poly.jl
@@ -734,37 +734,37 @@ Base.promote_rule(::Type{fmpz_poly}, ::Type{fmpz}) = fmpz_poly
 #
 ###############################################################################
 
-function Base.call(a::FmpzPolyRing)
+function (a::FmpzPolyRing)()
    z = fmpz_poly()
    z.parent = a
    return z
 end
 
-function Base.call(a::FmpzPolyRing, b::Int)
+function (a::FmpzPolyRing)(b::Int)
    z = fmpz_poly(b)
    z.parent = a
    return z
 end
 
-function Base.call(a::FmpzPolyRing, b::Integer)
+function (a::FmpzPolyRing)(b::Integer)
    z = fmpz_poly(fmpz(b))
    z.parent = a
    return z
 end
 
-function Base.call(a::FmpzPolyRing, b::fmpz)
+function (a::FmpzPolyRing)(b::fmpz)
    z = fmpz_poly(b)
    z.parent = a
    return z
 end
 
-function Base.call(a::FmpzPolyRing, b::Array{fmpz, 1})
+function (a::FmpzPolyRing)(b::Array{fmpz, 1})
    z = fmpz_poly(b)
    z.parent = a
    return z
 end
 
-Base.call(a::FmpzPolyRing, b::fmpz_poly) = b
+(a::FmpzPolyRing)(b::fmpz_poly) = b
 
 ###############################################################################
 #

--- a/src/flint/fmpz_rel_series.jl
+++ b/src/flint/fmpz_rel_series.jl
@@ -503,14 +503,14 @@ Base.promote_rule(::Type{fmpz_rel_series}, ::Type{fmpz}) = fmpz_rel_series
 #
 ###############################################################################
 
-function Base.call(a::FmpzRelSeriesRing)
+function (a::FmpzRelSeriesRing)()
    z = fmpz_rel_series()
    z.prec = a.prec_max
    z.parent = a
    return z
 end
 
-function Base.call(a::FmpzRelSeriesRing, b::Integer)
+function (a::FmpzRelSeriesRing)(b::Integer)
    if b == 0
       z = fmpz_rel_series()
       z.prec = a.prec_max
@@ -521,7 +521,7 @@ function Base.call(a::FmpzRelSeriesRing, b::Integer)
    return z
 end
 
-function Base.call(a::FmpzRelSeriesRing, b::fmpz)
+function (a::FmpzRelSeriesRing)(b::fmpz)
    if b == 0
       z = fmpz_rel_series()
       z.prec = a.prec_max
@@ -532,12 +532,12 @@ function Base.call(a::FmpzRelSeriesRing, b::fmpz)
    return z
 end
 
-function Base.call(a::FmpzRelSeriesRing, b::fmpz_rel_series)
+function (a::FmpzRelSeriesRing)(b::fmpz_rel_series)
    parent(b) != a && error("Unable to coerce power series")
    return b
 end
 
-function Base.call(a::FmpzRelSeriesRing, b::Array{fmpz, 1}, len::Int, prec::Int)
+function (a::FmpzRelSeriesRing)(b::Array{fmpz, 1}, len::Int, prec::Int)
    z = fmpz_rel_series(b, len, prec)
    z.parent = a
    return z

--- a/src/flint/fq.jl
+++ b/src/flint/fq.jl
@@ -475,24 +475,24 @@ Base.promote_rule(::Type{fq}, ::Type{fmpz}) = fq
 #
 ###############################################################################
 
-function Base.call(a::FqFiniteField)
+function (a::FqFiniteField)()
    z = fq(a)
    return z
 end
 
-Base.call(a::FqFiniteField, b::Integer) = a(fmpz(b))
+(a::FqFiniteField)(b::Integer) = a(fmpz(b))
 
-function Base.call(a::FqFiniteField, b::Int)
+function (a::FqFiniteField)(b::Int)
    z = fq(a, b)
    return z
 end
 
-function Base.call(a::FqFiniteField, b::fmpz)
+function (a::FqFiniteField)(b::fmpz)
    z = fq(a, b)
    return z
 end
 
-function Base.call(a::FqFiniteField, b::fq)
+function (a::FqFiniteField)(b::fq)
    parent(b) != a && error("Coercion between finite fields not implemented")
    return b
 end

--- a/src/flint/fq_nmod.jl
+++ b/src/flint/fq_nmod.jl
@@ -399,27 +399,27 @@ Base.promote_rule(::Type{fq_nmod}, ::Type{fmpz}) = fq_nmod
 #
 ###############################################################################
 
-function Base.call(a::FqNmodFiniteField)
+function (a::FqNmodFiniteField)()
    z = fq_nmod(a)
    z.parent = a
    return z
 end
 
-Base.call(a::FqNmodFiniteField, b::Integer) = a(fmpz(b))
+(a::FqNmodFiniteField)(b::Integer) = a(fmpz(b))
 
-function Base.call(a::FqNmodFiniteField, b::Int)
+function (a::FqNmodFiniteField)(b::Int)
    z = fq_nmod(a, b)
    z.parent = a
    return z
 end
 
-function Base.call(a::FqNmodFiniteField, b::fmpz)
+function (a::FqNmodFiniteField)(b::fmpz)
    z = fq_nmod(a, b)
    z.parent = a
    return z
 end
 
-function Base.call(a::FqNmodFiniteField, b::fq_nmod)
+function (a::FqNmodFiniteField)(b::fq_nmod)
    parent(b) != a && error("Coercion between finite fields not implemented")
    return b
 end

--- a/src/flint/fq_nmod_poly.jl
+++ b/src/flint/fq_nmod_poly.jl
@@ -616,7 +616,7 @@ Base.promote_rule(::Type{fq_nmod_poly}, ::Type{fq_nmod}) = fq_nmod_poly
 #
 ###############################################################################
 
-function Base.call(f::fq_nmod_poly, a::fq_nmod)
+function (f::fq_nmod_poly)(a::fq_nmod)
    if parent(a) != base_ring(f)
       return subst(f, a)
    end
@@ -629,27 +629,27 @@ end
 #
 ################################################################################
 
-function Base.call(R::FqNmodPolyRing)
+function (R::FqNmodPolyRing)()
    z = fq_nmod_poly()
    z.parent = R
    return z
 end
 
-function Base.call(R::FqNmodPolyRing, x::fq_nmod)
+function (R::FqNmodPolyRing)(x::fq_nmod)
   z = fq_nmod_poly(x)
   z.parent = R
   return z
 end
 
-function Base.call(R::FqNmodPolyRing, x::fmpz)
+function (R::FqNmodPolyRing)(x::fmpz)
    return R(base_ring(R)(x))
 end
 
-function Base.call(R::FqNmodPolyRing, x::Integer)
+function (R::FqNmodPolyRing)(x::Integer)
    return R(fmpz(x))
 end
 
-function Base.call(R::FqNmodPolyRing, x::Array{fq_nmod, 1})
+function (R::FqNmodPolyRing)(x::Array{fq_nmod, 1})
    length(x) == 0 && error("Array must be non-empty")
    base_ring(R) != parent(x[1]) && error("Coefficient rings must coincide")
    z = fq_nmod_poly(x)
@@ -657,25 +657,25 @@ function Base.call(R::FqNmodPolyRing, x::Array{fq_nmod, 1})
    return z
 end
 
-function Base.call(R::FqNmodPolyRing, x::Array{fmpz, 1})
+function (R::FqNmodPolyRing)(x::Array{fmpz, 1})
    length(x) == 0 && error("Array must be non-empty")
    z = fq_nmod_poly(x, base_ring(R))
    z.parent = R
    return z
 end
 
-function Base.call{T <: Integer}(R::FqNmodPolyRing, x::Array{T, 1})
+function (R::FqNmodPolyRing){T <: Integer}(x::Array{T, 1})
    length(x) == 0 && error("Array must be non-empty")
    return R(map(fmpz, x))
 end
 
-function Base.call(R::FqNmodPolyRing, x::fmpz_poly)
+function (R::FqNmodPolyRing)(x::fmpz_poly)
    z = fq_nmod_poly(x, base_ring(R))
    z.parent = R
    return z
 end
 
-function Base.call(R::FqNmodPolyRing, x::fq_nmod_poly)
+function (R::FqNmodPolyRing)(x::fq_nmod_poly)
   parent(x) != R && error("Unable to coerce to polynomial")
   return x
 end

--- a/src/flint/fq_nmod_rel_series.jl
+++ b/src/flint/fq_nmod_rel_series.jl
@@ -501,7 +501,7 @@ Base.promote_rule(::Type{fq_nmod_rel_series}, ::Type{fq_nmod}) = fq_nmod_rel_ser
 #
 ###############################################################################
 
-function Base.call(a::FqNmodRelSeriesRing)
+function (a::FqNmodRelSeriesRing)()
    ctx = base_ring(a)
    z = fq_nmod_rel_series(ctx)
    z.prec = a.prec_max
@@ -509,7 +509,7 @@ function Base.call(a::FqNmodRelSeriesRing)
    return z
 end
 
-function Base.call(a::FqNmodRelSeriesRing, b::Integer)
+function (a::FqNmodRelSeriesRing)(b::Integer)
    ctx = base_ring(a)
    if b == 0
       z = fq_nmod_rel_series(ctx)
@@ -521,7 +521,7 @@ function Base.call(a::FqNmodRelSeriesRing, b::Integer)
    return z
 end
 
-function Base.call(a::FqNmodRelSeriesRing, b::fmpz)
+function (a::FqNmodRelSeriesRing)(b::fmpz)
    ctx = base_ring(a)
    if b == 0
       z = fq_nmod_rel_series(ctx)
@@ -533,7 +533,7 @@ function Base.call(a::FqNmodRelSeriesRing, b::fmpz)
    return z
 end
 
-function Base.call(a::FqNmodRelSeriesRing, b::fq_nmod)
+function (a::FqNmodRelSeriesRing)(b::fq_nmod)
    ctx = base_ring(a)
    if b == 0
       z = fq_nmod_rel_series(ctx)
@@ -545,12 +545,12 @@ function Base.call(a::FqNmodRelSeriesRing, b::fq_nmod)
    return z
 end
 
-function Base.call(a::FqNmodRelSeriesRing, b::fq_nmod_rel_series)
+function (a::FqNmodRelSeriesRing)(b::fq_nmod_rel_series)
    parent(b) != a && error("Unable to coerce power series")
    return b
 end
 
-function Base.call(a::FqNmodRelSeriesRing, b::Array{fq_nmod, 1}, len::Int, prec::Int)
+function (a::FqNmodRelSeriesRing)(b::Array{fq_nmod, 1}, len::Int, prec::Int)
    ctx = base_ring(a)
    z = fq_nmod_rel_series(ctx, b, len, prec)
    z.parent = a

--- a/src/flint/fq_poly.jl
+++ b/src/flint/fq_poly.jl
@@ -603,7 +603,7 @@ Base.promote_rule(::Type{fq_poly}, ::Type{fq}) = fq_poly
 #
 ###############################################################################
 
-function Base.call(f::fq_poly, a::fq)
+function (f::fq_poly)(a::fq)
    if parent(a) != base_ring(f)
       return subst(f, a)
    end
@@ -616,27 +616,27 @@ end
 #
 ################################################################################
 
-function Base.call(R::FqPolyRing)
+function (R::FqPolyRing)()
    z = fq_poly()
    z.parent = R
    return z
 end
 
-function Base.call(R::FqPolyRing, x::fq)
+function (R::FqPolyRing)(x::fq)
   z = fq_poly(x)
   z.parent = R
   return z
 end
 
-function Base.call(R::FqPolyRing, x::fmpz)
+function (R::FqPolyRing)(x::fmpz)
    return R(base_ring(R)(x))
 end
 
-function Base.call(R::FqPolyRing, x::Integer)
+function (R::FqPolyRing)(x::Integer)
    return R(fmpz(x))
 end
 
-function Base.call(R::FqPolyRing, x::Array{fq, 1})
+function (R::FqPolyRing)(x::Array{fq, 1})
    length(x) == 0 && error("Array must be non-empty")
    base_ring(R) != parent(x[1]) && error("Coefficient rings must coincide")
    z = fq_poly(x)
@@ -644,25 +644,25 @@ function Base.call(R::FqPolyRing, x::Array{fq, 1})
    return z
 end
 
-function Base.call(R::FqPolyRing, x::Array{fmpz, 1})
+function (R::FqPolyRing)(x::Array{fmpz, 1})
    length(x) == 0 && error("Array must be non-empty")
    z = fq_poly(x, base_ring(R))
    z.parent = R
    return z
 end
 
-function Base.call{T <: Integer}(R::FqPolyRing, x::Array{T, 1})
+function (R::FqPolyRing){T <: Integer}(x::Array{T, 1})
    length(x) == 0 && error("Array must be non-empty")
    return R(map(fmpz, x))
 end
 
-function Base.call(R::FqPolyRing, x::fmpz_poly)
+function (R::FqPolyRing)(x::fmpz_poly)
    z = fq_poly(x, base_ring(R))
    z.parent = R
    return z
 end
 
-function Base.call(R::FqPolyRing, x::fq_poly)
+function (R::FqPolyRing)(x::fq_poly)
   parent(x) != R && error("Unable to coerce to polynomial")
   return x
 end

--- a/src/flint/fq_rel_series.jl
+++ b/src/flint/fq_rel_series.jl
@@ -500,7 +500,7 @@ Base.promote_rule(::Type{fq_rel_series}, ::Type{fq}) = fq_rel_series
 #
 ###############################################################################
 
-function Base.call(a::FqRelSeriesRing)
+function (a::FqRelSeriesRing)()
    ctx = base_ring(a)
    z = fq_rel_series(ctx)
    z.prec = a.prec_max
@@ -508,7 +508,7 @@ function Base.call(a::FqRelSeriesRing)
    return z
 end
 
-function Base.call(a::FqRelSeriesRing, b::Integer)
+function (a::FqRelSeriesRing)(b::Integer)
    ctx = base_ring(a)
    if b == 0
       z = fq_rel_series(ctx)
@@ -520,7 +520,7 @@ function Base.call(a::FqRelSeriesRing, b::Integer)
    return z
 end
 
-function Base.call(a::FqRelSeriesRing, b::fmpz)
+function (a::FqRelSeriesRing)(b::fmpz)
    ctx = base_ring(a)
    if b == 0
       z = fq_rel_series(ctx)
@@ -532,7 +532,7 @@ function Base.call(a::FqRelSeriesRing, b::fmpz)
    return z
 end
 
-function Base.call(a::FqRelSeriesRing, b::fq)
+function (a::FqRelSeriesRing)(b::fq)
    ctx = base_ring(a)
    if b == 0
       z = fq_rel_series(ctx)
@@ -544,12 +544,12 @@ function Base.call(a::FqRelSeriesRing, b::fq)
    return z
 end
 
-function Base.call(a::FqRelSeriesRing, b::fq_rel_series)
+function (a::FqRelSeriesRing)(b::fq_rel_series)
    parent(b) != a && error("Unable to coerce power series")
    return b
 end
 
-function Base.call(a::FqRelSeriesRing, b::Array{fq, 1}, len::Int, prec::Int)
+function (a::FqRelSeriesRing)(b::Array{fq, 1}, len::Int, prec::Int)
    ctx = base_ring(a)
    z = fq_rel_series(ctx, b, len, prec)
    z.parent = a

--- a/src/flint/nmod_mat.jl
+++ b/src/flint/nmod_mat.jl
@@ -604,13 +604,13 @@ Base.promote_rule(::Type{nmod_mat}, ::Type{fmpz}) = nmod_mat
 #
 ################################################################################
 
-function Base.call(a::NmodMatSpace)
+function (a::NmodMatSpace)()
   z = nmod_mat(a.rows, a.cols, a.n)
   z.parent = a
   return z
 end
 
-function Base.call(a::NmodMatSpace, b::Integer)
+function (a::NmodMatSpace)(b::Integer)
    M = a()
    for i = 1:a.rows
       for j = 1:a.cols
@@ -624,7 +624,7 @@ function Base.call(a::NmodMatSpace, b::Integer)
    return M
 end
 
-function Base.call(a::NmodMatSpace, b::fmpz)
+function (a::NmodMatSpace)(b::fmpz)
    M = a()
    for i = 1:a.rows
       for j = 1:a.cols
@@ -638,7 +638,7 @@ function Base.call(a::NmodMatSpace, b::fmpz)
    return M
 end
 
-function Base.call(a::NmodMatSpace, b::GenRes{fmpz})
+function (a::NmodMatSpace)(b::GenRes{fmpz})
    parent(b) != base_ring(a) && error("Unable to coerce to matrix")
    M = a()
    for i = 1:a.rows
@@ -653,28 +653,28 @@ function Base.call(a::NmodMatSpace, b::GenRes{fmpz})
    return M
 end
 
-function Base.call(a::NmodMatSpace, arr::Array{BigInt, 2}, transpose::Bool = false)
+function (a::NmodMatSpace)(arr::Array{BigInt, 2}, transpose::Bool = false)
   _check_dim(a.rows, a.cols, arr, transpose)
   z = nmod_mat(a.rows, a.cols, a.n, arr, transpose)
   z.parent = a
   return z
 end
 
-function Base.call(a::NmodMatSpace, arr::Array{fmpz, 2}, transpose::Bool = false)
+function (a::NmodMatSpace)(arr::Array{fmpz, 2}, transpose::Bool = false)
   _check_dim(a.rows, a.cols, arr, transpose)
   z = nmod_mat(a.rows, a.cols, a.n, arr, transpose)
   z.parent = a
   return z
 end
 
-function Base.call(a::NmodMatSpace, arr::Array{Int, 2}, transpose::Bool = false)
+function (a::NmodMatSpace)(arr::Array{Int, 2}, transpose::Bool = false)
   _check_dim(a.rows, a.cols, arr, transpose)
   z = nmod_mat(a.rows, a.cols, a.n, arr, transpose)
   z.parent = a
   return z
 end
 
-function Base.call(a::NmodMatSpace, arr::Array{GenRes{fmpz}, 2}, transpose::Bool = false)
+function (a::NmodMatSpace)(arr::Array{GenRes{fmpz}, 2}, transpose::Bool = false)
   _check_dim(a.rows, a.cols, arr, transpose)
   length(arr) == 0 && error("Array must be nonempty")
   (base_ring(a) != parent(arr[1])) && error("Elements must have same base ring")
@@ -683,7 +683,7 @@ function Base.call(a::NmodMatSpace, arr::Array{GenRes{fmpz}, 2}, transpose::Bool
   return z
 end
 
-function Base.call(a::NmodMatSpace, arr::Array{Int, 1})
+function (a::NmodMatSpace)(arr::Array{Int, 1})
   (length(arr) != a.cols * a.rows) &&
           error("Array must be of length ", a.cols * a.rows)
 
@@ -691,21 +691,21 @@ function Base.call(a::NmodMatSpace, arr::Array{Int, 1})
   return a(arr, true)
 end
 
-function Base.call(a::NmodMatSpace, arr::Array{BigInt, 1})
+function (a::NmodMatSpace)(arr::Array{BigInt, 1})
   (length(arr) != a.cols * a.rows) &&
           error("Array must be of length ", a.cols * a.rows)
   arr = reshape(arr,a.cols,a.rows)
   return a(arr, true)
 end
 
-function Base.call(a::NmodMatSpace, arr::Array{fmpz, 1})
+function (a::NmodMatSpace)(arr::Array{fmpz, 1})
   (length(arr) != a.cols * a.rows) &&
           error("Array must be of length ", a.cols * a.rows)
   arr = reshape(arr,a.cols,a.rows)
   return a(arr, true)
 end
 
-function Base.call(a::NmodMatSpace, arr::Array{GenRes{fmpz}, 1})
+function (a::NmodMatSpace)(arr::Array{GenRes{fmpz}, 1})
   (length(arr) != a.cols * a.rows) &&
           error("Array must be of length ", a.cols * a.rows)
   z = nmod_mat(a.rows, a.cols, a.n, arr)
@@ -714,7 +714,7 @@ function Base.call(a::NmodMatSpace, arr::Array{GenRes{fmpz}, 1})
   return z
 end
 
-function Base.call(a::NmodMatSpace, b::fmpz_mat)
+function (a::NmodMatSpace)(b::fmpz_mat)
   (a.cols != b.c || a.rows != b.r) && error("Dimensions do not fit")
   z = nmod_mat(a.n, b)
   z.parent = a

--- a/src/flint/nmod_poly.jl
+++ b/src/flint/nmod_poly.jl
@@ -930,7 +930,7 @@ Base.promote_rule(::Type{nmod_poly}, ::Type{GenRes{fmpz}}) = nmod_poly
 #
 ###############################################################################
 
-function Base.call(f::nmod_poly, a::GenRes{fmpz})
+function (f::nmod_poly)(a::GenRes{fmpz})
    if parent(a) != base_ring(f)
       return subst(f, a)
    end
@@ -943,51 +943,51 @@ end
 #
 ################################################################################
 
-function Base.call(R::NmodPolyRing)
+function (R::NmodPolyRing)()
   z = nmod_poly(R.n)
   z.parent = R
   return z
 end
 
-function Base.call(R::NmodPolyRing, x::fmpz)
+function (R::NmodPolyRing)(x::fmpz)
   r = ccall((:fmpz_fdiv_ui, :libflint), UInt, (Ptr{fmpz}, UInt), &x, R.n)
   z = nmod_poly(R.n, r)
   z.parent = R
   return z
 end
 
-function Base.call(R::NmodPolyRing, x::UInt)
+function (R::NmodPolyRing)(x::UInt)
   z = nmod_poly(R.n, x)
   z.parent = R
   return z
 end
 
-function Base.call(R::NmodPolyRing, x::Integer)
+function (R::NmodPolyRing)(x::Integer)
   z = nmod_poly(R.n, x)
   z.parent = R
   return z
 end
 
-function Base.call(R::NmodPolyRing, x::GenRes{fmpz})
+function (R::NmodPolyRing)(x::GenRes{fmpz})
   base_ring(R) != parent(x) && error("Wrong parents")
   z = nmod_poly(R.n, UInt(x.data))
   z.parent = R
   return z
 end
 
-function Base.call(R::NmodPolyRing, arr::Array{fmpz, 1})
+function (R::NmodPolyRing)(arr::Array{fmpz, 1})
   z = nmod_poly(R.n, arr)
   z.parent = R
   return z
 end
 
-function Base.call(R::NmodPolyRing, arr::Array{UInt, 1})
+function (R::NmodPolyRing)(arr::Array{UInt, 1})
   z = nmod_poly(R.n, arr)
   z.parent = R
   return z
 end
 
-function Base.call(R::NmodPolyRing, arr::Array{GenRes{fmpz}, 1})
+function (R::NmodPolyRing)(arr::Array{GenRes{fmpz}, 1})
   if length(arr) > 0
      (base_ring(R) != parent(arr[1])) && error("Wrong parents")
   end
@@ -996,7 +996,7 @@ function Base.call(R::NmodPolyRing, arr::Array{GenRes{fmpz}, 1})
   return z
 end
 
-function Base.call(R::NmodPolyRing, x::fmpz_poly)
+function (R::NmodPolyRing)(x::fmpz_poly)
   z = nmod_poly(R.n, x)
   z.parent = R
   return z

--- a/src/flint/padic.jl
+++ b/src/flint/padic.jl
@@ -592,27 +592,27 @@ promote_rule(::Type{padic}, ::Type{fmpq}) = padic
 #
 ###############################################################################
 
-function Base.call(R::FlintPadicField)
+function (R::FlintPadicField)()
    z = padic(R.prec_max)
    z.parent = R
    return z
 end
 
-function Base.call(R::FlintPadicField, n::fmpz)
+function (R::FlintPadicField)(n::fmpz)
    if n == 1
       N = 0
    else
       p = prime(R)
-      N, = remove(n, p) 
+      N, = remove(n, p)
    end
    z = padic(N + R.prec_max)
-   ccall((:padic_set_fmpz, :libflint), Void, 
+   ccall((:padic_set_fmpz, :libflint), Void,
          (Ptr{padic}, Ptr{fmpz}, Ptr{FlintPadicField}), &z, &n, &R)
    z.parent = R
    return z
 end
 
-function Base.call(R::FlintPadicField, n::fmpq)
+function (R::FlintPadicField)(n::fmpq)
    m = den(n)
    if m == 1
       return R(num(n))
@@ -621,18 +621,18 @@ function Base.call(R::FlintPadicField, n::fmpq)
    if m == p
       N = -1
    else
-     N = -flog(m, p) 
+     N = -flog(m, p)
    end
    z = padic(N + R.prec_max)
-   ccall((:padic_set_fmpq, :libflint), Void, 
+   ccall((:padic_set_fmpq, :libflint), Void,
          (Ptr{padic}, Ptr{fmpq}, Ptr{FlintPadicField}), &z, &n, &R)
    z.parent = R
    return z
 end
 
-Base.call(R::FlintPadicField, n::Integer) = R(fmpz(n))
+(R::FlintPadicField)(n::Integer) = R(fmpz(n))
 
-function Base.call(R::FlintPadicField, n::padic)
+function (R::FlintPadicField)(n::padic)
    parent(n) != R && error("Unable to coerce into p-adic field")
    return n
 end

--- a/src/flint/perm.jl
+++ b/src/flint/perm.jl
@@ -161,20 +161,20 @@ end
 #
 ###############################################################################
 
-function Base.call(R::FlintPermGroup)
+function (R::FlintPermGroup)()
    z = perm(R.n)
    z.parent = R
    return z
 end
 
-function Base.call(R::FlintPermGroup, a::Array{Int, 1})
+function (R::FlintPermGroup)(a::Array{Int, 1})
    length(a) != R.n && error("Unable to coerce to permutation")
    z = perm(a)
    z.parent = R
    return z
 end
 
-function Base.call(R::FlintPermGroup, a::perm)
+function (R::FlintPermGroup)(a::perm)
    parent(a) != R && error("Unable to coerce to permutation")
    return a
 end

--- a/src/generic/Fraction.jl
+++ b/src/generic/Fraction.jl
@@ -710,30 +710,30 @@ end
 #
 ###############################################################################
 
-function Base.call{T <: RingElem}(a::GenFracField{T}, b::RingElem)
+function (a::GenFracField{T}){T <: RingElem}(b::RingElem)
    return a(base_ring(a)(b))
 end
 
-function Base.call{T <: RingElem}(a::GenFracField{T})
+function (a::GenFracField{T}){T <: RingElem}()
    z = GenFrac{T}(zero(base_ring(a)), one(base_ring(a)))
    z.parent = a
    return z
 end
 
-function Base.call{T <: RingElem}(a::GenFracField{T}, b::fmpz)
+function (a::GenFracField{T}){T <: RingElem}(b::fmpz)
    z = GenFrac{T}(base_ring(a)(b), one(base_ring(a)))
    z.parent = a
    return z
 end
 
-function Base.call{T <: RingElem}(a::GenFracField{T}, b::T)
+function (a::GenFracField{T}){T <: RingElem}(b::T)
    parent(b) != base_ring(a) && error("Could not coerce to fraction")
    z = GenFrac{T}(b, one(base_ring(a)))
    z.parent = a
    return z
 end
 
-function Base.call{T <: RingElem}(a::GenFracField{T}, b::T, c::T)
+function (a::GenFracField{T}){T <: RingElem}(b::T, c::T)
    parent(b) != base_ring(a) && error("Could not coerce to fraction")
    parent(c) != base_ring(a) && error("Could not coerce to fraction")
    z = GenFrac{T}(b, c)
@@ -741,33 +741,33 @@ function Base.call{T <: RingElem}(a::GenFracField{T}, b::T, c::T)
    return z
 end
 
-function Base.call{T <: RingElem}(a::GenFracField{T}, b::T, c::Integer)
+function (a::GenFracField{T}){T <: RingElem}(b::T, c::Integer)
    parent(b) != base_ring(a) && error("Could not coerce to fraction")
    z = GenFrac{T}(b, base_ring(a)(c))
    z.parent = a
    return z
 end
 
-function Base.call{T <: RingElem}(a::GenFracField{T}, b::Integer, c::T)
+function (a::GenFracField{T}){T <: RingElem}(b::Integer, c::T)
    parent(c) != base_ring(a) && error("Could not coerce to fraction")
    z = GenFrac{T}(base_ring(a)(b), c)
    z.parent = a
    return z
 end
 
-function Base.call{T <: RingElem}(a::GenFracField{T}, b::Integer)
+function (a::GenFracField{T}){T <: RingElem}(b::Integer)
    z = GenFrac{T}(base_ring(a)(b), one(base_ring(a)))
    z.parent = a
    return z
 end
 
-function Base.call{T <: RingElem}(a::GenFracField{T}, b::Integer, c::Integer)
+function (a::GenFracField{T}){T <: RingElem}(b::Integer, c::Integer)
    z = GenFrac{T}(base_ring(a)(b), base_ring(a)(c))
    z.parent = a
    return z
 end
 
-function Base.call{T <: RingElem}(a::GenFracField{T}, b::GenFrac{T})
+function (a::GenFracField{T}){T <: RingElem}(b::GenFrac{T})
    a != parent(b) && error("Could not coerce to fraction")
    return b
 end

--- a/src/generic/Matrix.jl
+++ b/src/generic/Matrix.jl
@@ -2830,7 +2830,7 @@ end
 #
 ###############################################################################
 
-function Base.call{T <: RingElem}(a::GenMatSpace{T}, b::fmpz_mat)
+function (a::GenMatSpace{T}){T <: RingElem}(b::fmpz_mat)
   if a.rows != rows(b) || a.cols != cols(b)
     error("incompatible matrix dimensions")
   end
@@ -2844,11 +2844,11 @@ function Base.call{T <: RingElem}(a::GenMatSpace{T}, b::fmpz_mat)
   return A
 end
 
-function Base.call{T <: RingElem}(a::GenMatSpace{T}, b::RingElem)
+function (a::GenMatSpace{T}){T <: RingElem}(b::RingElem)
    return a(base_ring(a)(b))
 end
 
-function Base.call{T <: RingElem}(a::GenMatSpace{T})
+function (a::GenMatSpace{T}){T <: RingElem}()
    entries = Array(T, a.rows, a.cols)
    for i = 1:a.rows
       for j = 1:a.cols
@@ -2860,7 +2860,7 @@ function Base.call{T <: RingElem}(a::GenMatSpace{T})
    return z
 end
 
-function Base.call{T <: RingElem}(a::GenMatSpace{T}, b::Integer)
+function (a::GenMatSpace{T}){T <: RingElem}(b::Integer)
    entries = Array(T, a.rows, a.cols)
    for i = 1:a.rows
       for j = 1:a.cols
@@ -2876,7 +2876,7 @@ function Base.call{T <: RingElem}(a::GenMatSpace{T}, b::Integer)
    return z
 end
 
-function Base.call{T <: RingElem}(a::GenMatSpace{T}, b::fmpz)
+function (a::GenMatSpace{T}){T <: RingElem}(b::fmpz)
    entries = Array(T, a.rows, a.cols)
    for i = 1:a.rows
       for j = 1:a.cols
@@ -2892,7 +2892,7 @@ function Base.call{T <: RingElem}(a::GenMatSpace{T}, b::fmpz)
    return z
 end
 
-function Base.call{T <: RingElem}(a::GenMatSpace{T}, b::T)
+function (a::GenMatSpace{T}){T <: RingElem}(b::T)
    parent(b) != base_ring(a) && error("Unable to coerce to matrix")
    entries = Array(T, a.rows, a.cols)
    for i = 1:a.rows
@@ -2909,12 +2909,12 @@ function Base.call{T <: RingElem}(a::GenMatSpace{T}, b::T)
    return z
 end
 
-function Base.call{T <: RingElem}(a::GenMatSpace{T}, b::GenMat{T})
+function (a::GenMatSpace{T}){T <: RingElem}(b::GenMat{T})
    parent(b) != a && error("Unable to coerce matrix")
    return b
 end
 
-function Base.call{T <: RingElem}(a::GenMatSpace{T}, b::Array{T, 2})
+function (a::GenMatSpace{T}){T <: RingElem}(b::Array{T, 2})
    if length(b) > 0
       parent(b[1, 1]) != base_ring(a) && error("Unable to coerce to matrix")
    end

--- a/src/generic/Poly.jl
+++ b/src/generic/Poly.jl
@@ -2088,35 +2088,35 @@ end
 #
 ###############################################################################
 
-function Base.call{T <: RingElem}(a::GenPolyRing{T}, b::RingElem)
+function (a::GenPolyRing{T}){T <: RingElem}(b::RingElem)
    return a(base_ring(a)(b))
 end
 
-function Base.call{T <: RingElem}(a::GenPolyRing{T})
+function (a::GenPolyRing{T}){T <: RingElem}()
    z = GenPoly{T}()
    z.parent = a
    return z
 end
 
-function Base.call{T <: RingElem}(a::GenPolyRing{T}, b::Integer)
+function (a::GenPolyRing{T}){T <: RingElem}(b::Integer)
    z = GenPoly{T}(base_ring(a)(b))
    z.parent = a
    return z
 end
 
-function Base.call{T <: RingElem}(a::GenPolyRing{T}, b::T)
+function (a::GenPolyRing{T}){T <: RingElem}(b::T)
    parent(b) != base_ring(a) && error("Unable to coerce to polynomial")
    z = GenPoly{T}(b)
    z.parent = a
    return z
 end
 
-function Base.call{T <: RingElem}(a::GenPolyRing{T}, b::PolyElem{T})
+function (a::GenPolyRing{T}){T <: RingElem}(b::PolyElem{T})
    parent(b) != a && error("Unable to coerce polynomial")
    return b
 end
 
-function Base.call{T <: RingElem}(a::GenPolyRing{T}, b::Array{T, 1})
+function (a::GenPolyRing{T}){T <: RingElem}(b::Array{T, 1})
    if length(b) > 0
       parent(b[1]) != base_ring(a) && error("Unable to coerce to polynomial")
    end
@@ -2149,6 +2149,6 @@ function PolynomialRing(R::Ring, s::AbstractString{}; cached::Bool = true)
 end
 
 # S, x = R["x"] syntax
-getindex(R::Ring, s::ASCIIString) = PolynomialRing(R, s)
+getindex(R::Ring, s::String) = PolynomialRing(R, s)
 
-getindex{T}(R::Tuple{Ring,T}, s::ASCIIString) = PolynomialRing(R[1], s)
+getindex{T}(R::Tuple{Ring,T}, s::String) = PolynomialRing(R[1], s)

--- a/src/generic/RelSeries.jl
+++ b/src/generic/RelSeries.jl
@@ -1038,17 +1038,17 @@ end
 #
 ###############################################################################
 
-function Base.call{T <: RingElem}(a::GenRelSeriesRing{T}, b::RingElem)
+function (a::GenRelSeriesRing{T}){T <: RingElem}(b::RingElem)
    return a(base_ring(a)(b))
 end
 
-function Base.call{T <: RingElem}(a::GenRelSeriesRing{T})
+function (a::GenRelSeriesRing{T}){T <: RingElem}()
    z = GenRelSeries{T}(Array(T, 0), 0, a.prec_max)
    z.parent = a
    return z
 end
 
-function Base.call{T <: RingElem}(a::GenRelSeriesRing{T}, b::Integer)
+function (a::GenRelSeriesRing{T}){T <: RingElem}(b::Integer)
    if b == 0
       z = GenRelSeries{T}(Array(T, 0), 0, a.prec_max)
    else
@@ -1058,7 +1058,7 @@ function Base.call{T <: RingElem}(a::GenRelSeriesRing{T}, b::Integer)
    return z
 end
 
-function Base.call{T <: RingElem}(a::GenRelSeriesRing{T}, b::fmpz)
+function (a::GenRelSeriesRing{T}){T <: RingElem}(b::fmpz)
    if b == 0
       z = GenRelSeries{T}(Array(T, 0), 0, a.prec_max)
    else
@@ -1068,7 +1068,7 @@ function Base.call{T <: RingElem}(a::GenRelSeriesRing{T}, b::fmpz)
    return z
 end
 
-function Base.call{T <: RingElem}(a::GenRelSeriesRing{T}, b::T)
+function (a::GenRelSeriesRing{T}){T <: RingElem}(b::T)
    parent(b) != base_ring(a) && error("Unable to coerce to power series")
    if b == 0
       z = GenRelSeries{T}(Array(T, 0), 0, a.prec_max)
@@ -1079,12 +1079,12 @@ function Base.call{T <: RingElem}(a::GenRelSeriesRing{T}, b::T)
    return z
 end
 
-function Base.call{T <: RingElem}(a::GenRelSeriesRing{T}, b::SeriesElem{T})
+function (a::GenRelSeriesRing{T}){T <: RingElem}(b::SeriesElem{T})
    parent(b) != a && error("Unable to coerce power series")
    return b
 end
 
-function Base.call{T <: RingElem}(a::GenRelSeriesRing{T}, b::Array{T, 1}, len::Int, prec::Int)
+function (a::GenRelSeriesRing{T}){T <: RingElem}(b::Array{T, 1}, len::Int, prec::Int)
    if length(b) > 0
       parent(b[1]) != base_ring(a) && error("Unable to coerce to power series")
    end

--- a/src/generic/Residue.jl
+++ b/src/generic/Residue.jl
@@ -507,36 +507,36 @@ end
 #
 ###############################################################################
 
-function Base.call{T <: RingElem}(a::GenResRing{T}, b::RingElem)
+function (a::GenResRing{T}){T <: RingElem}(b::RingElem)
    return a(base_ring(a)(b))
 end
 
-function Base.call{T <: RingElem}(a::GenResRing{T})
+function (a::GenResRing{T}){T <: RingElem}()
    z = GenRes{T}(zero(base_ring(a)))
    z.parent = a
    return z
 end
 
-function Base.call{T <: RingElem}(a::GenResRing{T}, b::Integer)
+function (a::GenResRing{T}){T <: RingElem}(b::Integer)
    z = GenRes{T}(mod(base_ring(a)(b), modulus(a)))
    z.parent = a
    return z
 end
 
-function Base.call{T <: RingElem}(a::GenResRing{T}, b::fmpz)
+function (a::GenResRing{T}){T <: RingElem}(b::fmpz)
    z = GenRes{T}(mod(base_ring(a)(b), modulus(a)))
    z.parent = a
    return z
 end
 
-function Base.call{T <: RingElem}(a::GenResRing{T}, b::T)
+function (a::GenResRing{T}){T <: RingElem}(b::T)
    base_ring(a) != parent(b) && error("Operation on incompatible objects")
    z = GenRes{T}(mod(b, modulus(a)))
    z.parent = a
    return z
 end
 
-function Base.call{T <: RingElem}(a::GenResRing{T}, b::ResElem{T})
+function (a::GenResRing{T}){T <: RingElem}(b::ResElem{T})
    a != parent(b) && error("Operation on incompatible objects")
    return b
 end

--- a/src/pari/PariIdeal.jl
+++ b/src/pari/PariIdeal.jl
@@ -405,7 +405,7 @@ end
 #
 ###############################################################################
 
-function Base.call(ord::PariIdealSet, id::Ptr{Int})
+function (ord::PariIdealSet)(id::Ptr{Int})
    return PariIdeal(id, PariIdealSet(ord))
 end
 

--- a/src/pari/pari_frac.jl
+++ b/src/pari/pari_frac.jl
@@ -92,7 +92,7 @@ function fmpq!(z::fmpq, g::Ptr{Int})
    end
 end
 
-function call(::FlintRationalField, g::pari_rat)
+function (::FlintRationalField)(g::pari_rat)
    r = fmpq()
    fmpq!(r, g.d)
    return r

--- a/src/pari/pari_int.jl
+++ b/src/pari/pari_int.jl
@@ -92,7 +92,7 @@ function fmpz!(z::fmpz, g::Ptr{Int})
    return z
 end
 
-function call(::FlintIntegerRing, g::pari_int)
+function (::FlintIntegerRing)(g::pari_int)
    z = fmpz()
    fmpz!(z, g.d)
    return z
@@ -118,7 +118,7 @@ end
 #
 ###############################################################################
 
-function Base.call(ord::PariIntegerRing, n::Ptr{Int})
+function (ord::PariIntegerRing)(n::Ptr{Int})
    return fmpz!(fmpz(), n)
 end
 

--- a/src/pari/pari_maximal_order_elem.jl
+++ b/src/pari/pari_maximal_order_elem.jl
@@ -23,9 +23,9 @@ parent(a::pari_maximal_order_elem) = a.parent
 residue(data::Ptr{Int}) = pari_load(data, 3)
 
 modulus(data::Ptr{Int}) = pari_load(data, 2)
-   
+
 function basistoalg(nf::Ptr{Int}, data::Ptr{Int})
-   return ccall((:basistoalg, :libpari), Ptr{Int}, 
+   return ccall((:basistoalg, :libpari), Ptr{Int},
                 (Ptr{Int}, Ptr{Int}), nf, data)
 end
 
@@ -74,48 +74,48 @@ end
 #
 ###############################################################################
 
-function Base.call(ord::PariMaximalOrder)
+function (ord::PariMaximalOrder)()
    av = unsafe_load(avma, 1)
-   data = ccall((:algtobasis, :libpari), Ptr{Int}, 
+   data = ccall((:algtobasis, :libpari), Ptr{Int},
                  (Ptr{Int}, Ptr{Int}), ord.pari_nf.data, pari(fmpz()).d)
    unsafe_store!(avma, av, 1)
    return pari_maximal_order_elem(data, ord)
 end
 
-function Base.call(ord::PariMaximalOrder, b::fmpq_poly)
+function (ord::PariMaximalOrder)(b::fmpq_poly)
    av = unsafe_load(avma, 1)
-   data = ccall((:algtobasis, :libpari), Ptr{Int}, 
+   data = ccall((:algtobasis, :libpari), Ptr{Int},
                  (Ptr{Int}, Ptr{Int}), ord.pari_nf.data, pari(b).d)
    unsafe_store!(avma, av, 1)
    return pari_maximal_order_elem(data, ord)
 end
 
-function Base.call(ord::PariMaximalOrder, b::nf_elem)
+function (ord::PariMaximalOrder)(b::nf_elem)
    av = unsafe_load(avma, 1)
    par = b.parent.pol.parent
-   data = ccall((:algtobasis, :libpari), Ptr{Int}, 
+   data = ccall((:algtobasis, :libpari), Ptr{Int},
                  (Ptr{Int}, Ptr{Int}), ord.pari_nf.data, pari(par(b)).d)
    unsafe_store!(avma, av, 1)
    return pari_maximal_order_elem(data, ord)
 end
 
-function Base.call(ord::PariMaximalOrder, b::fmpz)
+function (ord::PariMaximalOrder)(b::fmpz)
    av = unsafe_load(avma, 1)
-   data = ccall((:algtobasis, :libpari), Ptr{Int}, 
+   data = ccall((:algtobasis, :libpari), Ptr{Int},
                  (Ptr{Int}, Ptr{Int}), ord.pari_nf.data, pari(b).d)
    unsafe_store!(avma, av, 1)
    return pari_maximal_order_elem(data, ord)
 end
 
-function Base.call(ord::PariMaximalOrder, b::Integer)
+function (ord::PariMaximalOrder)(b::Integer)
    av = unsafe_load(avma, 1)
-   data = ccall((:algtobasis, :libpari), Ptr{Int}, 
+   data = ccall((:algtobasis, :libpari), Ptr{Int},
                  (Ptr{Int}, Ptr{Int}), ord.pari_nf.data, pari(fmpz(b)).d)
    unsafe_store!(avma, av, 1)
    return pari_maximal_order_elem(data, ord)
 end
 
-function Base.call(ord::PariMaximalOrder, b::pari_maximal_order_elem)
+function (ord::PariMaximalOrder)(b::pari_maximal_order_elem)
    parent(b) != ord && error("Unable to coerce maximal order element")
    return b
 end

--- a/src/pari/pari_polmod.jl
+++ b/src/pari/pari_polmod.jl
@@ -26,7 +26,7 @@ end
 #
 ###########################################################################################
 
-function Base.call{S <: RingElem}(ord::PariPolModRing{S}, b::Ptr{Int})
+function (ord::PariPolModRing{S}){S <: RingElem}(b::Ptr{Int})
    z = pari_polmod{S}(b)
    z.parent = ord
    return z

--- a/src/pari/pari_poly.jl
+++ b/src/pari/pari_poly.jl
@@ -106,14 +106,14 @@ end
 #
 ###############################################################################
 
-function Base.call(ord::PariPolyRing{pari_int}, n::Ptr{Int})
+function (ord::PariPolyRing{pari_int})(n::Ptr{Int})
    pol = pari_poly{pari_int}(n)
    pol.parent = PariPolyRing{pari_int}(PariZZ, var(ord))
    return pol
 end
 
 
-function Base.call(a::FmpzPolyRing, g::pari_poly{pari_int})
+function (a::FmpzPolyRing)(g::pari_poly{pari_int})
    z = fmpz_poly()
    z.parent = a
    fmpz_poly!(z, g.d)

--- a/src/pari/pari_poly2.jl
+++ b/src/pari/pari_poly2.jl
@@ -73,13 +73,13 @@ end
 #
 ###############################################################################
 
-function Base.call(ord::PariPolyRing{pari_rat}, n::Ptr{Int})
+function (ord::PariPolyRing{pari_rat})(n::Ptr{Int})
    pol = pari_poly{pari_rat}(n)
    pol.parent = PariPolyRing{pari_rat}(PariQQ, var(ord))
    return pol
 end
 
-function Base.call(a::FmpqPolyRing, g::pari_poly{pari_rat})
+function (a::FmpqPolyRing)(g::pari_poly{pari_rat})
    z = fmpq_poly()
    z.parent = a
    fmpq_poly!(z, g.d)


### PR DESCRIPTION
I've fixed all of the `Base.call` deprecations that I can find, and fixed a few other minor deprecations as well. `using Nemo` now prints no warnings in Julia v0.5. Tests are passing for me locally, but I'm not familiar with this package, so I'd appreciate some review of my changes to make sure they're all OK. 