### PR TITLE
fix hash function

### DIFF
--- a/src/flint/perm.jl
+++ b/src/flint/perm.jl
@@ -38,8 +38,8 @@ end
 
 function Base.hash(a::perm, h::UInt)
    b = 0x595dee0e71d271d0%UInt
-   for i in 1:a.d
-         b $= hash(a[i - 1], h) $ h
+   for i in 1:length(a.d)
+         b $= hash(a[i], h) $ h
          b = (b << 1) | (b >> (sizeof(Int)*8 - 1))
    end
    return b


### PR DESCRIPTION
hash function of Nemo.perm was broken, producing
```
MethodError: no method matching colon(::Int32, ::Array{Int32,1})

in hash(::Nemo.perm, ::UInt32) at /home/kalmar/.julia/v0.5/Nemo/src/flint/perm.jl:41
```

I don't quite understand what the function does by itself, but in one of my projects I was told to use the existing hash for `Array` types, along
 ```
hash(X::MyTypeWrappingVector, h::UInt) = hash(X.vector, hash(MyTypeWrappingVector, h))
```