### PR TITLE
Fix powering with literals for Nemo types

### DIFF
--- a/src/Rings.jl
+++ b/src/Rings.jl
@@ -104,6 +104,8 @@ function addmul!(z::T, x::T, y::T, c::T) where {T <: RingElem}
    return z
 end
 
+Base.literal_pow(::typeof(^), x::T, ::Val{p}) where {p, T <: RingElem} = x^p
+
 ###############################################################################
 #
 #   Baby-steps giant-steps powering


### PR DESCRIPTION
On 0.7 the handling of literal powers like x^-1 is changed. It goes through a separate code path (`Base.literal_pow`). This won't work for us, so we should just let it call ordinary powering.